### PR TITLE
Make Cloud Logging writes asynchronous via CloudLoggingHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
   * Update the `[Unreleased]` url: `v1.0.0...HEAD` -> `v2.0.0...HEAD`
 
 -->
+## [Unreleased]
+
+### Changed
+
+* `_CloudLogger.write_cloud_logging_entry` is now asynchronous. Writes
+  are dispatched through `google.cloud.logging.handlers.CloudLoggingHandler`
+  (default transport `BackgroundThreadTransport`) instead of calling
+  `Logger.log_struct` synchronously, eliminating the ~50–150 ms gRPC
+  RTT per call on the per-step critical path. Multiple entries are
+  batched into a single `write_entries` RPC.
+
+  Reads following a write may see up to `background_max_latency_s`
+  (2 s default) of staleness — negligible for goodput aggregates over
+  minutes of training, and `GoodputMonitor`'s subprocess pattern is
+  unaffected. Call `GoodputRecorder.flush()` for a strict fence.
+
+  Commit errors are now logged by `google.cloud.logging`'s logger
+  instead of raised inline.
+
+### Added
+
+* `GoodputRecorder.flush()`: block until pending async writes have
+  committed. For strict read-after-write fencing.
+* `GoodputRecorder(..., background_grace_period_s=, background_batch_size=,
+  background_max_latency_s=)`: tuning knobs forwarded to
+  `BackgroundThreadTransport`. Defaults: 5 s / 100 entries / 2 s.
+
 ## [0.0.16] - 2026-01-10
 
 * Add Exclusion API post-processing support & example offline scripts.

--- a/ml_goodput_measurement/src/goodput.py
+++ b/ml_goodput_measurement/src/goodput.py
@@ -6,6 +6,7 @@ Deviation.
 """
 
 import datetime
+import functools
 import logging
 import threading
 from typing import Any, Optional, Union
@@ -78,17 +79,33 @@ class _CloudLogger:
       job_name: str,
       log_name: str,
       max_logs_retention_period: Optional[datetime.timedelta] = None,
+      *,
+      background_grace_period_s: float = 5.0,
+      background_batch_size: int = 100,
+      background_max_latency_s: float = 2.0,
   ):
     """_CloudLogger constructor.
+
+    Writes are dispatched asynchronously via `CloudLoggingHandler` /
+    `BackgroundThreadTransport`; `write_cloud_logging_entry` returns
+    immediately and a daemon thread commits batched entries.
 
     Args:
       job_name: Name of the job the _CloudLogger is for.
       log_name: Name of the log being written.
       max_logs_retention_period: Maximum retention period for Cloud Logging
         logs.
+
+    Keyword-only:
+      background_grace_period_s: Shutdown drain budget. Default 5.0.
+      background_batch_size: Entries per `write_entries` RPC. Default 100.
+      background_max_latency_s: Max queue dwell after the first entry
+        arrives, before committing. Default 2.0.
     """
 
     import google.cloud.logging  # pylint: disable=g-import-not-at-top
+    from google.cloud.logging_v2.handlers import CloudLoggingHandler  # pylint: disable=g-import-not-at-top
+    from google.cloud.logging_v2.handlers.transports import BackgroundThreadTransport  # pylint: disable=g-import-not-at-top
 
     self.job_name = job_name
     logging_client = google.cloud.logging.Client()
@@ -102,19 +119,52 @@ class _CloudLogger:
         else _CLOUD_LOGGING_DEFAULT_RETENTION
     )
 
+    # Async write path: synchronous `Logger.log_struct` adds ~50-150 ms of
+    # gRPC RTT per call, which compounds on the per-step recorder calls.
+    # `CloudLoggingHandler` gives us a daemon-thread worker, batched commits,
+    # and atexit-safe shutdown.
+    transport_factory = functools.partial(
+        BackgroundThreadTransport,
+        grace_period=background_grace_period_s,
+        batch_size=background_batch_size,
+        max_latency=background_max_latency_s,
+    )
+    self._async_handler = CloudLoggingHandler(
+        client=logging_client,
+        name=log_name,
+        transport=transport_factory,  # type: ignore[arg-type]
+    )
+    # One stdlib logger per _CloudLogger *instance* (not per log_name).
+    # `logging.getLogger(name)` returns a process-global singleton, so if
+    # two _CloudLogger instances are created with the same log_name in the
+    # same process (sequential jobs in a notebook, reusable worker
+    # processes, tests), the second `addHandler` call would attach a
+    # second CloudLoggingHandler onto the shared logger and every entry
+    # would be uploaded twice. Adding `id(self)` makes the name unique
+    # per instance; propagate=False keeps dict payloads off the root
+    # logger.
+    self._async_logger = logging.getLogger(
+        f'_ml_goodput_async.{log_name}.{id(self)}'
+    )
+    self._async_logger.setLevel(logging.INFO)
+    self._async_logger.addHandler(self._async_handler)
+    self._async_logger.propagate = False
+
   def write_cloud_logging_entry(self, entry) -> None:
-    """Writes an entry to the Cloud Logging logger at INFO level.
+    """Writes an entry asynchronously at INFO level.
 
     Args:
       entry: JSON-serializable structured log dictionary.
     """
     if entry is None:
       return
-    if entry[_JOB_NAME] == self.job_name:
-      self.logger.log_struct(
-          entry,
-          severity='INFO',
-      )
+    if entry[_JOB_NAME] != self.job_name:
+      return
+    self._async_logger.info(entry)
+
+  def flush(self) -> None:
+    """Block until every entry enqueued so far has been committed."""
+    self._async_handler.flush()
 
   def _get_filter_msg(
       self,
@@ -196,6 +246,10 @@ class _CloudLogger:
   ):
     """Queries Cloud Logging entries for the specific job.
 
+    Reads following a write may see up to `background_max_latency_s`
+    (2 s default) of staleness, since writes commit asynchronously.
+    Call `GoodputRecorder.flush()` for a strict fence.
+
     Args:
       start_time: The start time of the query window.
       end_time: The end time of the query window.
@@ -254,6 +308,10 @@ class GoodputRecorder:
       logger_name: str,
       logging_enabled=False,
       cloud_logger: Optional[_CloudLogger] = None,
+      *,
+      background_grace_period_s: float = 5.0,
+      background_batch_size: int = 100,
+      background_max_latency_s: float = 2.0,
   ):
     """GoodputRecorder constructor.
 
@@ -266,6 +324,11 @@ class GoodputRecorder:
         this value to True if the Recorder is being called from TPU worker 0 and
         the application's configurations request Goodput logging.
       cloud_logger: Should never be passed directly by the user.
+
+    Keyword-only:
+      background_grace_period_s: Forwarded to the underlying `_CloudLogger`.
+      background_batch_size: Forwarded to the underlying `_CloudLogger`.
+      background_max_latency_s: Forwarded to the underlying `_CloudLogger`.
     """
     self.job_name = job_name
     # If logging is disabled for this process, do not create a _cloud_logger
@@ -278,7 +341,23 @@ class GoodputRecorder:
     if cloud_logger is not None:
       self._cloud_logger = cloud_logger
     else:
-      self._cloud_logger = _CloudLogger(job_name, logger_name)
+      self._cloud_logger = _CloudLogger(
+          job_name,
+          logger_name,
+          background_grace_period_s=background_grace_period_s,
+          background_batch_size=background_batch_size,
+          background_max_latency_s=background_max_latency_s,
+      )
+
+  def flush(self) -> None:
+    """Block until pending async writes from this recorder have committed.
+
+    Use for strict read-after-write fencing (unit tests, end-of-training
+    finalization, hand-off to another process).
+    """
+    if self._cloud_logger is None:
+      return
+    self._cloud_logger.flush()
 
   def record_step_start_time(
       self, step: int, start_time: Optional[datetime.datetime] = None

--- a/ml_goodput_measurement/tests/cloud_logging_test.py
+++ b/ml_goodput_measurement/tests/cloud_logging_test.py
@@ -1,5 +1,6 @@
 """Tests for the _CloudLogger class."""
 import datetime
+import logging
 from unittest import mock
 
 from absl.testing import absltest
@@ -77,7 +78,7 @@ class CloudLoggerTest(absltest.TestCase):
 
   @mock.patch('google.cloud.logging.Client')
   def test_write_logs_entry(self, mock_client_cls):
-    """Verifies entries are written to the logger."""
+    """Verifies entries are routed via the async CloudLoggingHandler."""
     mock_gcp_logger = mock_client_cls.return_value.logger.return_value
 
     mock_client_instance = mock_client_cls.return_value
@@ -86,9 +87,17 @@ class CloudLoggerTest(absltest.TestCase):
     logger = goodput._CloudLogger(self.job_name, self.log_name)
 
     entry = {'job_name': self.job_name, 'data': 123}
-    logger.write_cloud_logging_entry(entry)
+    with mock.patch.object(logger._async_handler, 'emit') as mock_emit:
+      logger.write_cloud_logging_entry(entry)
 
-    mock_gcp_logger.log_struct.assert_called_with(entry, severity='INFO')
+      mock_emit.assert_called_once()
+      record = mock_emit.call_args[0][0]
+      self.assertEqual(record.msg, entry)
+      self.assertEqual(record.levelno, logging.INFO)
+
+    # Synchronous `Logger.log_struct` is no longer called inline; the
+    # async transport commits via `client.logging_api.write_entries`.
+    mock_gcp_logger.log_struct.assert_not_called()
 
   @mock.patch('google.cloud.logging.Client')
   def test_default_retention(self, mock_client_cls):
@@ -133,6 +142,100 @@ class CloudLoggerTest(absltest.TestCase):
     self.assertEqual(
         calculator._cloud_logger.retention_period, custom_retention
     )
+
+
+class CloudLoggerAsyncWritesTest(absltest.TestCase):
+  """Cloud Logging writes are dispatched via CloudLoggingHandler."""
+
+  def setUp(self):
+    super().setUp()
+    self.job_name = 'test-job'
+    self.log_name = 'test-log'
+
+  @mock.patch('google.cloud.logging.Client')
+  def test_handler_attached_with_propagate_false(self, mock_client_cls):
+    mock_client_cls.return_value.project = 'p'
+
+    logger = _CloudLogger(self.job_name, self.log_name)
+
+    self.assertIsNotNone(logger._async_handler)
+    self.assertIn(logger._async_handler, logger._async_logger.handlers)
+    self.assertFalse(
+        logger._async_logger.propagate,
+        'must not propagate dict payloads to root handlers',
+    )
+
+  @mock.patch('google.cloud.logging.Client')
+  def test_write_drops_entries_for_other_job(self, mock_client_cls):
+    """write_cloud_logging_entry is a no-op for entries with a foreign job."""
+    mock_client_cls.return_value.project = 'p'
+
+    logger = _CloudLogger(self.job_name, self.log_name)
+    with mock.patch.object(logger._async_handler, 'emit') as mock_emit:
+      logger.write_cloud_logging_entry(
+          {goodput._JOB_NAME: 'someone-else', 'data': 1}
+      )
+      logger.write_cloud_logging_entry(None)
+      mock_emit.assert_not_called()
+
+  @mock.patch('google.cloud.logging.Client')
+  def test_flush_forwards_to_handler(self, mock_client_cls):
+    mock_client_cls.return_value.project = 'p'
+    logger = _CloudLogger(self.job_name, self.log_name)
+    with mock.patch.object(logger._async_handler, 'flush') as mock_flush:
+      logger.flush()
+      mock_flush.assert_called_once()
+
+  @mock.patch('google.cloud.logging.Client')
+  def test_two_instances_same_log_name_do_not_share_handlers(
+      self, mock_client_cls
+  ):
+    """Regression: each instance must own its own stdlib logger.
+
+    `logging.getLogger(name)` returns a singleton per name, so naming the
+    backing logger only by `log_name` would cause a second instance's
+    `addHandler` to attach onto the first instance's logger — every entry
+    would then be uploaded once per accumulated handler.
+    """
+    mock_client_cls.return_value.project = 'p'
+
+    a = _CloudLogger(self.job_name, self.log_name)
+    b = _CloudLogger(self.job_name, self.log_name)
+
+    self.assertIsNot(a._async_logger, b._async_logger)
+    self.assertEqual(a._async_logger.handlers, [a._async_handler])
+    self.assertEqual(b._async_logger.handlers, [b._async_handler])
+
+    # Writing on `b` must not fan out to `a`'s handler.
+    entry = {goodput._JOB_NAME: self.job_name, 'data': 1}
+    with mock.patch.object(a._async_handler, 'emit') as emit_a, \
+        mock.patch.object(b._async_handler, 'emit') as emit_b:
+      b.write_cloud_logging_entry(entry)
+      emit_a.assert_not_called()
+      emit_b.assert_called_once()
+
+
+class GoodputRecorderFlushTest(absltest.TestCase):
+  """`GoodputRecorder.flush` is the public entry point for explicit drains."""
+
+  @mock.patch('google.cloud.logging.Client')
+  def test_flush_forwards_to_cloud_logger(self, mock_client_cls):
+    mock_client_cls.return_value.project = 'p'
+    recorder = goodput.GoodputRecorder(
+        'test-job', 'test-log', logging_enabled=True
+    )
+    with mock.patch.object(recorder._cloud_logger, 'flush') as mock_flush:
+      recorder.flush()
+      mock_flush.assert_called_once()
+
+  def test_flush_is_noop_when_logging_disabled(self):
+    recorder = goodput.GoodputRecorder(
+        'test-job', 'test-log', logging_enabled=False
+    )
+    self.assertIsNone(recorder._cloud_logger)
+    # Should not raise.
+    recorder.flush()
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
`_CloudLogger.write_cloud_logging_entry` previously called `Logger.log_struct`
synchronously, blocking the calling thread on a ~50-150 ms gRPC RTT per
call. On the per-step critical path of a training loop (`record_step_*_time`,
`record_data_loading_*_time`, ...), this added up to non-trivial wall-time
overhead per step.

This PR makes writes asynchronous by delegating to google-cloud-logging's
`CloudLoggingHandler`, whose default transport is `BackgroundThreadTransport`.
Rather than rolling our own daemon-thread + queue + drain loop, we reuse
the upstream worker that already handles atexit, graceful shutdown, batched
commit, and error logging.

> **Note**: this PR has been substantially rewritten from the original
> opt-in `enable_background_writes` design after reviewer feedback. The
> implementation went from ~150 LoC to ~30 LoC by delegating to
> `BackgroundThreadTransport` instead of reimplementing it.

## Public surface

- `_CloudLogger(..., background_grace_period_s=5.0, background_batch_size=100, background_max_latency_s=2.0)`
- `GoodputRecorder` forwards all three tuning knobs.
- `_CloudLogger.flush()`: drain the background queue (= `handler.flush()` → `queue.join()`).

## Why delegate to `CloudLoggingHandler`

- **N entries committed in 1 `write_entries` RPC** (vs N individual `log_struct` calls).
- **LogRecord.created is captured at the `.info()` call site**, so the GCP entry timestamp reflects when the caller wrote — `GoodputCalculator`'s `timestamp>"…"` filtering remains accurate even when the worker flushes later.
- **`BackgroundThreadTransport.grace_period`** bounds shutdown if the GCP endpoint is slow; no atexit hang risk.
- **`_safely_commit_batch`** logs commit errors via `google.cloud.logging`'s logger — no silent drop.

## BREAKING CHANGES (suggest bumping to 0.1.0)

- Callers that read back via `GoodputCalculator` immediately after a write must now call `_CloudLogger.flush()` first.
- Callers that relied on synchronous error propagation from `log_struct` will now see errors via `google.cloud.logging`'s logger instead.

## Tests

- `test_write_logs_entry` rewritten to assert the async route via `_async_handler.emit` (capturing the `LogRecord` with the dict payload).
- 3 new tests in `CloudLoggerAsyncWritesTest`: handler attachment with `propagate=False`, no-op for foreign-job entries, `flush()` forwards to handler.

## Reviewer-comment status

- @Ethanlm "default should be True": resolved — async is now the only path, no flag.
- @YixuanWang-99 "drain timing issue": resolved — upstream `_get_many` doesn't have this bug (drains on every wake until empty or batch_size).
- @dipannita08 "make knobs configurable through the Recorder": resolved — `background_grace_period_s` / `background_batch_size` / `background_max_latency_s` are all forwarded.
- @dipannita08 "profile traces in description": pending — will collect in a follow-up before merging.

## TODO before merge

- [x] Profile traces (xprof / per-step host timeline before & after) on a 7x-256  AXLearn run.

Before: 


<img width="893" height="184" alt="Screenshot 2026-06-07 at 21 23 08" src="https://github.com/user-attachments/assets/2cd92a2a-5d7e-4d66-a98a-de45364d8132" />

<img width="1126" height="515" alt="Screenshot 2026-06-07 at 21 08 38" src="https://github.com/user-attachments/assets/2af9633c-0f6b-48f7-afcc-ead71857ea31" />


After:

<img width="1006" height="184" alt="Screenshot 2026-06-07 at 21 23 29" src="https://github.com/user-attachments/assets/8d228900-d1d4-4392-8edf-77d73784ece5" />


<img width="999" height="749" alt="Screenshot 2026-06-07 at 21 10 26" src="https://github.com/user-attachments/assets/b9476186-cacb-4d87-af26-a6f9471c600b" />



- [x] CLA signature.