### PR TITLE
Speed up (and fix fatal barrier timeout on) final Goodput flush during workload shutdown.

### DIFF
--- a/ml_goodput_measurement/src/goodput.py
+++ b/ml_goodput_measurement/src/goodput.py
@@ -1565,7 +1565,25 @@ class GoodputCalculator(goodput_exclusion.GoodputExclusion):
     """
     # Get the logs for the interval and validate the interval window.
     self._get_interval_log_entries(interval_start, interval_end)
+    return self._compute_job_goodput_interval_metrics(
+        interval_start, interval_end
+    )
 
+  def _compute_job_goodput_interval_metrics(
+      self, interval_start: datetime.datetime, interval_end: datetime.datetime
+  ) -> tuple[
+      float,
+      UnproductiveTimeDict,
+      int,
+      float,
+      int,
+  ]:
+    """Computes Goodput and Badput metrics from the currently loaded self._interval_entries.
+
+    Callers are responsible for populating self._interval_entries (e.g. via
+    _get_interval_log_entries) with entries bounded to
+    [interval_start, interval_end] before calling this method.
+    """
     total_job_time = self._get_total_job_time_from_interval(
         interval_start, interval_end
     )
@@ -1961,3 +1979,98 @@ class GoodputCalculator(goodput_exclusion.GoodputExclusion):
               (interval_end - interval_start).total_seconds()
           ),
       }
+
+  def get_interval_metric_details_for_windows(
+      self,
+      window_sizes_seconds: list[int],
+      now: Optional[datetime.datetime] = None,
+  ) -> dict[int, IntervalWorkloadMetricDetails]:
+    """Computes interval metric details for multiple rolling windows that share the same end time.
+
+    All windows end at `now`, so the log entries for the largest window are a
+    superset of every smaller window's entries. This fetches Cloud Logging
+    entries once for the largest window and reuses that single fetch for
+    every window size, instead of one fetch per window size.
+
+    Args:
+      window_sizes_seconds: The rolling window sizes, in seconds.
+      now: The shared end time for every window. Defaults to the current
+        time.
+
+    Returns:
+      A dict mapping each window size to its IntervalWorkloadMetricDetails.
+    """
+    if not window_sizes_seconds:
+      return {}
+    if now is None:
+      now = datetime.datetime.now(datetime.timezone.utc)
+
+    def _empty_details(window_size: int) -> IntervalWorkloadMetricDetails:
+      return {
+          IntervalMetricType.INTERVAL_GOODPUT.value: {},
+          IntervalMetricType.INTERVAL_BADPUT.value: {},
+          IntervalMetricType.INTERVAL_SIZE.value: window_size,
+      }
+
+    max_window_size = max(window_sizes_seconds)
+    try:
+      self._get_interval_log_entries(
+          now - datetime.timedelta(seconds=max_window_size), now
+      )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      logger.warning(
+          'Failed to fetch interval log entries for rolling window query: %s',
+          e,
+      )
+      return {
+          window_size: _empty_details(window_size)
+          for window_size in window_sizes_seconds
+      }
+
+    all_entries = self._interval_entries
+    results: dict[int, IntervalWorkloadMetricDetails] = {}
+    try:
+      for window_size in window_sizes_seconds:
+        window_start = now - datetime.timedelta(seconds=window_size)
+        # Slicing the superset to fetching this window directly.
+        self._interval_entries = [
+            entry
+            for entry in all_entries
+            if (entry_timestamp := get_timestamp_from_log_entry(entry))
+            is not None
+            and entry_timestamp > window_start
+        ]
+        try:
+          if not self._interval_entries:
+            raise ValueError(
+                'No log entries found within the interval window between'
+                ' %s and %s.' % (window_start, now)
+            )
+          (
+              interval_goodput,
+              interval_badput_breakdown,
+              _,
+              _,
+              _,
+          ) = self._compute_job_goodput_interval_metrics(window_start, now)
+          results[window_size] = {
+              IntervalMetricType.INTERVAL_GOODPUT.value: {
+                  GoodputType.TOTAL: interval_goodput
+              },
+              IntervalMetricType.INTERVAL_BADPUT.value: (
+                  interval_badput_breakdown
+              ),
+              IntervalMetricType.INTERVAL_SIZE.value: window_size,
+          }
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          logger.warning(
+              'Failed to get interval metric details for window size %ss:'
+              ' %s',
+              window_size,
+              e,
+          )
+          results[window_size] = _empty_details(window_size)
+    finally:
+      self._interval_entries = all_entries
+
+    return results

--- a/ml_goodput_measurement/src/monitoring.py
+++ b/ml_goodput_measurement/src/monitoring.py
@@ -10,7 +10,7 @@ import math
 import multiprocessing
 from multiprocessing import synchronize
 import os
-import time
+import threading
 
 from cloud_goodput.ml_goodput_measurement.src import gcp_metrics
 from cloud_goodput.ml_goodput_measurement.src import goodput
@@ -39,7 +39,69 @@ _PROCESS_TERMINATION_TIMEOUT_SECONDS = 10
 logger = logging.getLogger(__name__)
 
 
-def _goodput_worker(config: dict, termination_event: synchronize.Event):
+def _query_and_upload_goodput_once(
+    calculator: GoodputCalculator,
+    summary_writer: writer.SummaryWriter,
+    metrics_sender: GCPMetrics | None,
+    config: dict,
+    pid: int,
+) -> None:
+  """Performs a single cumulative goodput query and upload cycle.
+
+  Used both by the periodic loop in _goodput_worker and for the final,
+  warm-cache flush performed just before the worker exits.
+  """
+  try:
+    job_goodput, job_badput, last_step = calculator.get_job_goodput(
+        include_badput_breakdown=config['include_badput_breakdown']
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Error while querying goodput for job %s. Skipping this'
+        ' cycle. Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+    return
+
+  try:
+    _upload_goodput_metrics_to_tensorboard(
+        summary_writer,
+        job_goodput,
+        job_badput,
+        last_step,
+        config['include_badput_breakdown'],
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Could not upload goodput metrics to Tensorboard for job'
+        ' %s. Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+
+  try:
+    if config['gcp_options'].enable_gcp_goodput_metrics and metrics_sender:
+      # Final attempt: get details from the calculator's state and upload
+      details = calculator.get_job_goodput_details()
+      _upload_goodput_metrics_to_gcm(metrics_sender, details, config)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Could not get details or upload metrics to Google Cloud'
+        ' Monitoring for job %s. Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+
+
+def _goodput_worker(
+    config: dict,
+    termination_event: synchronize.Event,
+    final_flush_event: synchronize.Event,
+):
   """Worker process for querying and uploading cumulative goodput."""
   pid = os.getpid()
   logger.info(
@@ -52,53 +114,22 @@ def _goodput_worker(config: dict, termination_event: synchronize.Event):
   summary_writer = _create_tensorboard_writer(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['upload_interval'])
-    # Query metrics and update the cache.
-    try:
-      job_goodput, job_badput, last_step = calculator.get_job_goodput(
-          include_badput_breakdown=config['include_badput_breakdown']
-      )
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Error while querying goodput for job %s. Skipping this'
-          ' cycle. Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
-      continue
+  while not termination_event.wait(timeout=config['upload_interval']):
+    _query_and_upload_goodput_once(
+        calculator, summary_writer, metrics_sender, config, pid
+    )
 
-    try:
-      _upload_goodput_metrics_to_tensorboard(
-          summary_writer,
-          job_goodput,
-          job_badput,
-          last_step,
-          config['include_badput_breakdown'],
-      )
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Could not upload goodput metrics to Tensorboard for job'
-          ' %s. Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
-
-    try:
-      if config['gcp_options'].enable_gcp_goodput_metrics and metrics_sender:
-        # Final attempt: get details from the calculator's state and upload
-        details = calculator.get_job_goodput_details()
-        _upload_goodput_metrics_to_gcm(metrics_sender, details, config)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Could not get details or upload metrics to Google Cloud'
-          ' Monitoring for job %s. Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
+  if final_flush_event.is_set():
+    # The calculator's cache is already warm from the loop above, so this
+    # final query only fetches entries written since the last cycle.
+    logger.info(
+        '[PID: %s] Performing final goodput query and upload for job: %s',
+        pid,
+        config['job_name'],
+    )
+    _query_and_upload_goodput_once(
+        calculator, summary_writer, metrics_sender, config, pid
+    )
 
   summary_writer.close()
   logger.info(
@@ -108,7 +139,62 @@ def _goodput_worker(config: dict, termination_event: synchronize.Event):
   )
 
 
-def _step_deviation_worker(config: dict, termination_event: synchronize.Event):
+def _query_and_upload_step_deviation_once(
+    calculator: GoodputCalculator,
+    summary_writer: writer.SummaryWriter,
+    metrics_sender: GCPMetrics | None,
+    config: dict,
+    pid: int,
+) -> None:
+  """Performs a single step deviation query and upload cycle.
+
+  Used both by the periodic loop in _step_deviation_worker and for the
+  final, warm-cache flush performed just before the worker exits.
+  """
+  try:
+    step_dev = calculator.get_step_deviation(
+        config['configured_ideal_step_time']
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Error getting step deviation for job %s. Skipping this'
+        ' cycle. Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+    return
+  try:
+    _write_step_deviation_to_tensorboard(summary_writer, step_dev)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Could not write step deviation to Tensorboard for job %s.'
+        ' Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+  try:
+    if (
+        config['gcp_options'].enable_gcp_step_deviation_metrics
+        and metrics_sender
+    ):
+      _send_step_deviation_metric_to_gcp(metrics_sender, step_dev, config)
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Could not send step deviation metric to GCP for job %s.'
+        ' Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+
+
+def _step_deviation_worker(
+    config: dict,
+    termination_event: synchronize.Event,
+    final_flush_event: synchronize.Event,
+):
   """Worker process for querying and uploading step deviation."""
   pid = os.getpid()
   logger.info(
@@ -121,45 +207,23 @@ def _step_deviation_worker(config: dict, termination_event: synchronize.Event):
   summary_writer = _create_tensorboard_writer(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['step_deviation_interval_seconds'])
-    try:
-      step_dev = calculator.get_step_deviation(
-          config['configured_ideal_step_time']
-      )
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Error getting step deviation for job %s. Skipping this'
-          ' cycle. Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
-      continue
-    try:
-      _write_step_deviation_to_tensorboard(summary_writer, step_dev)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Could not write step deviation to Tensorboard for job %s.'
-          ' Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
-    try:
-      if (
-          config['gcp_options'].enable_gcp_step_deviation_metrics
-          and metrics_sender
-      ):
-        _send_step_deviation_metric_to_gcp(metrics_sender, step_dev, config)
-    except Exception as e:  # pylint: disable=broad-exception-caught
-      logger.warning(
-          '[PID: %s] Could not send step deviation metric to GCP for job %s.'
-          ' Error: %s',
-          pid,
-          config['job_name'],
-          e,
-      )
+  while not termination_event.wait(
+      timeout=config['step_deviation_interval_seconds']
+  ):
+    _query_and_upload_step_deviation_once(
+        calculator, summary_writer, metrics_sender, config, pid
+    )
+
+  if final_flush_event.is_set():
+    logger.info(
+        '[PID: %s] Performing final step deviation query and upload for'
+        ' job: %s',
+        pid,
+        config['job_name'],
+    )
+    _query_and_upload_step_deviation_once(
+        calculator, summary_writer, metrics_sender, config, pid
+    )
 
   summary_writer.close()
   logger.info(
@@ -169,7 +233,55 @@ def _step_deviation_worker(config: dict, termination_event: synchronize.Event):
   )
 
 
-def _rolling_window_worker(config: dict, termination_event: synchronize.Event):
+def _query_and_upload_rolling_window_once(
+    calculator: GoodputCalculator,
+    metrics_sender: GCPMetrics | None,
+    config: dict,
+    pid: int,
+) -> None:
+  """Performs a single rolling window goodput query and upload cycle.
+
+  Used both by the periodic loop in _rolling_window_worker and for the
+  final, warm-cache flush performed just before the worker exits. All
+  configured window sizes share the same end time, so a single fetch
+  covering the largest window is reused for every smaller window instead of
+  issuing one Cloud Logging fetch per window size.
+  """
+  now = datetime.datetime.now(datetime.timezone.utc)
+  try:
+    details_by_window = calculator.get_interval_metric_details_for_windows(
+        config['rolling_windows'], now
+    )
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logger.warning(
+        '[PID: %s] Error in rolling window query for job %s. Error: %s',
+        pid,
+        config['job_name'],
+        e,
+    )
+    return
+
+  for window_size, interval_metric_details in details_by_window.items():
+    try:
+      _upload_interval_goodput_metrics_to_gcm(
+          metrics_sender, interval_metric_details, config
+      )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      logger.warning(
+          '[PID: %s] Error uploading rolling window (size: %ss) for job %s.'
+          ' Error: %s',
+          pid,
+          window_size,
+          config['job_name'],
+          e,
+      )
+
+
+def _rolling_window_worker(
+    config: dict,
+    termination_event: synchronize.Event,
+    final_flush_event: synchronize.Event,
+):
   """Worker process for querying and uploading rolling window goodput."""
   pid = os.getpid()
   logger.info(
@@ -180,35 +292,62 @@ def _rolling_window_worker(config: dict, termination_event: synchronize.Event):
   calculator = _create_goodput_calculator(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['upload_interval'])
-    now = datetime.datetime.now(datetime.timezone.utc)
-    for window_size in config['rolling_windows']:
-      try:
-        window_end = now
-        window_start = now - datetime.timedelta(seconds=window_size)
-        window_start = window_start.replace(tzinfo=datetime.timezone.utc)
-        interval_metric_details = calculator.get_interval_metric_details(
-            window_start, window_end
-        )
-        _upload_interval_goodput_metrics_to_gcm(
-            metrics_sender, interval_metric_details, config
-        )
-      except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.warning(
-            '[PID: %s] Error in rolling window (size: %ss) for job %s.'
-            ' Error: %s',
-            pid,
-            window_size,
-            config['job_name'],
-            e,
-        )
+  while not termination_event.wait(timeout=config['upload_interval']):
+    _query_and_upload_rolling_window_once(
+        calculator, metrics_sender, config, pid
+    )
+
+  if final_flush_event.is_set():
+    logger.info(
+        '[PID: %s] Performing final rolling window goodput query and upload'
+        ' for job: %s',
+        pid,
+        config['job_name'],
+    )
+    _query_and_upload_rolling_window_once(
+        calculator, metrics_sender, config, pid
+    )
 
   logger.info(
       '[PID: %s] Rolling window worker process for job %s stopped.',
       pid,
       config['job_name'],
   )
+
+
+def _run_with_timeout(
+    func,
+    timeout_seconds: float | None,
+    description: str,
+) -> None:
+  """Runs func, abandoning it if it does not complete within timeout_seconds.
+
+  If timeout_seconds is None, func is run synchronously with no timeout,
+  preserving the default blocking behavior. Otherwise func is run in a daemon
+  thread so that a slow or hung network call (e.g. fetching log entries or
+  uploading metrics) cannot block workload shutdown past timeout_seconds.
+
+  Args:
+    func: A zero-argument callable to run.
+    timeout_seconds: The maximum time to wait for func to complete, or None
+      to wait indefinitely.
+    description: A human-readable description of func, used for logging if
+      it is abandoned.
+  """
+  if timeout_seconds is None:
+    func()
+    return
+  thread = threading.Thread(target=func, daemon=True)
+  thread.start()
+  thread.join(timeout=timeout_seconds)
+  if thread.is_alive():
+    logger.warning(
+        '%s did not complete within %s seconds and will be abandoned to'
+        ' avoid blocking workload shutdown. The job may be missing its'
+        ' final goodput metrics upload.',
+        description,
+        timeout_seconds,
+    )
 
 
 def _create_goodput_calculator(config: dict) -> GoodputCalculator:
@@ -720,6 +859,9 @@ class GoodputMonitor:
       step_deviation_interval_seconds=10,
       gcp_options: GCPOptions = GCPOptions(),
       skip_final_flush: bool = False,
+      final_flush_timeout_seconds: (
+          float | None
+      ) = _PROCESS_TERMINATION_TIMEOUT_SECONDS,
   ):
     """Initializes the GoodputMonitor.
 
@@ -745,6 +887,18 @@ class GoodputMonitor:
       gcp_options: The options for Google Cloud Monitoring.
       skip_final_flush: Whether to skip the final goodput metrics flush upon
         termination.
+      final_flush_timeout_seconds: The maximum time to wait for the final
+        goodput metrics flush (query plus Tensorboard/GCM upload) to
+        complete upon termination. If an uploader process is running, this
+        is used as the join timeout so the worker has time to perform the
+        flush itself using its warm cache before exiting; if no uploader
+        process was ever started, it instead bounds a one-off cold query
+        run by the caller. Defaults to _PROCESS_TERMINATION_TIMEOUT_SECONDS.
+        If the flush does not complete within this timeout, it is abandoned
+        (and the worker, if any, is terminated) so that it does not block
+        workload shutdown (e.g. behind a multi-host termination barrier).
+        Pass None to block until the flush completes (the legacy behavior).
+        Has no effect if skip_final_flush is True.
     """
     if not monitoring_enabled:
       logger.info(
@@ -754,6 +908,7 @@ class GoodputMonitor:
       return
     self._initialized = True
     self._skip_final_flush = skip_final_flush
+    self._final_flush_timeout_seconds = final_flush_timeout_seconds
 
     self._goodput_calculator = GoodputCalculator(
         job_name=job_name,
@@ -804,12 +959,15 @@ class GoodputMonitor:
     # Process management attributes
     self._goodput_process = None
     self._goodput_termination_event = multiprocessing.Event()
+    self._goodput_final_flush_event = multiprocessing.Event()
 
     self._step_deviation_process = None
     self._step_deviation_termination_event = multiprocessing.Event()
+    self._step_deviation_final_flush_event = multiprocessing.Event()
 
     self._rolling_window_process = None
     self._rolling_window_termination_event = multiprocessing.Event()
+    self._rolling_window_final_flush_event = multiprocessing.Event()
 
   def __del__(self):
     if not getattr(self, '_initialized', False):
@@ -828,6 +986,22 @@ class GoodputMonitor:
     except Exception:  # pylint: disable=broad-except
       pass
 
+  def _worker_join_timeout(self, should_skip: bool) -> float | None:
+    """Returns the timeout to use when joining an uploader process.
+
+    When a final flush is requested, the worker performs it just before
+    exiting (see _goodput_worker et al.), so the join must wait long enough
+    to cover that query and upload too. final_flush_timeout_seconds is the
+    customer-facing knob for that combined wait. Otherwise (skip_final_flush),
+    there is no flush work to wait for, so the fixed process-termination
+    timeout applies.
+    """
+    if should_skip:
+      return _PROCESS_TERMINATION_TIMEOUT_SECONDS
+    return getattr(
+        self, '_final_flush_timeout_seconds', _PROCESS_TERMINATION_TIMEOUT_SECONDS
+    )
+
   def start_goodput_uploader(self):
     """Starts the goodput uploader process."""
     if not self._initialized:
@@ -839,9 +1013,14 @@ class GoodputMonitor:
       )
       return
     self._goodput_termination_event.clear()
+    self._goodput_final_flush_event.clear()
     self._goodput_process = multiprocessing.Process(
         target=_goodput_worker,
-        args=(self._worker_config, self._goodput_termination_event),
+        args=(
+            self._worker_config,
+            self._goodput_termination_event,
+            self._goodput_final_flush_event,
+        ),
         daemon=True,
     )
     self._goodput_process.start()
@@ -856,11 +1035,23 @@ class GoodputMonitor:
     if not self._initialized:
       return
 
+    should_skip = (
+        skip_final_flush
+        if skip_final_flush is not None
+        else getattr(self, '_skip_final_flush', False)
+    )
+    worker_was_running = self._goodput_process is not None
+
     if self._goodput_process:
       pid = self._goodput_process.pid
       logger.info('Shutting down cumulative goodput process (PID: %s)', pid)
+      # Perform final query and upload using its own warm cache before it exits.
+      if not should_skip:
+        self._goodput_final_flush_event.set()
       self._goodput_termination_event.set()
-      self._goodput_process.join(timeout=_PROCESS_TERMINATION_TIMEOUT_SECONDS)
+      self._goodput_process.join(
+          timeout=self._worker_join_timeout(should_skip)
+      )
       if self._goodput_process.is_alive():
         logger.warning(
             'Cumulative goodput process (PID: %s) did not exit gracefully.'
@@ -879,17 +1070,18 @@ class GoodputMonitor:
             exit_code,
         )
     self._goodput_process = None
-    should_skip = (
-        skip_final_flush
-        if skip_final_flush is not None
-        else getattr(self, '_skip_final_flush', False)
-    )
-    if not should_skip:
-      self._final_goodput_query_and_upload()
+    if not should_skip and not worker_was_running:
+      # No uploader process was ever started, so there is no warm cache to
+      # draw from. Fall back to a one-off query, bounded by
+      # final_flush_timeout_seconds.
+      _run_with_timeout(
+          self._final_goodput_query_and_upload,
+          getattr(self, '_final_flush_timeout_seconds', None),
+          f'Final goodput query and upload for job: {self._worker_config["job_name"]}',
+      )
 
   def _final_goodput_query_and_upload(self):
     """Performs final cumulative goodput query and uploads data to Tensorboard & GCM."""
-    time.sleep(self._worker_config['upload_interval'])
     try:
       calculator = self._goodput_calculator
       job_goodput, job_badput, last_step = calculator.get_job_goodput(
@@ -949,9 +1141,14 @@ class GoodputMonitor:
       )
       return
     self._step_deviation_termination_event.clear()
+    self._step_deviation_final_flush_event.clear()
     self._step_deviation_process = multiprocessing.Process(
         target=_step_deviation_worker,
-        args=(self._worker_config, self._step_deviation_termination_event),
+        args=(
+            self._worker_config,
+            self._step_deviation_termination_event,
+            self._step_deviation_final_flush_event,
+        ),
         daemon=True,
     )
     self._step_deviation_process.start()
@@ -966,13 +1163,22 @@ class GoodputMonitor:
     if not self._initialized:
       return
 
+    should_skip = (
+        skip_final_flush
+        if skip_final_flush is not None
+        else getattr(self, '_skip_final_flush', False)
+    )
+    worker_was_running = self._step_deviation_process is not None
+
     if self._step_deviation_process:
       pid = self._step_deviation_process.pid
       logger.info('Shutting down step deviation process (PID: %s)', pid)
 
+      if not should_skip:
+        self._step_deviation_final_flush_event.set()
       self._step_deviation_termination_event.set()
       self._step_deviation_process.join(
-          timeout=_PROCESS_TERMINATION_TIMEOUT_SECONDS
+          timeout=self._worker_join_timeout(should_skip)
       )
 
       if self._step_deviation_process.is_alive():
@@ -994,17 +1200,15 @@ class GoodputMonitor:
         )
 
     self._step_deviation_process = None
-    should_skip = (
-        skip_final_flush
-        if skip_final_flush is not None
-        else getattr(self, '_skip_final_flush', False)
-    )
-    if not should_skip:
-      self._final_step_deviation_query_and_upload()
+    if not should_skip and not worker_was_running:
+      _run_with_timeout(
+          self._final_step_deviation_query_and_upload,
+          getattr(self, '_final_flush_timeout_seconds', None),
+          f'Final step deviation query and upload for job: {self._worker_config["job_name"]}',
+      )
 
   def _final_step_deviation_query_and_upload(self):
     """Performs a final step deviation query and upload."""
-    time.sleep(self._worker_config['upload_interval'])
     try:
       calculator = self._goodput_calculator
       step_dev = calculator.get_step_deviation(
@@ -1045,9 +1249,14 @@ class GoodputMonitor:
       return
     self._worker_config['rolling_windows'] = rolling_windows_seconds
     self._rolling_window_termination_event.clear()
+    self._rolling_window_final_flush_event.clear()
     self._rolling_window_process = multiprocessing.Process(
         target=_rolling_window_worker,
-        args=(self._worker_config, self._rolling_window_termination_event),
+        args=(
+            self._worker_config,
+            self._rolling_window_termination_event,
+            self._rolling_window_final_flush_event,
+        ),
         daemon=True,
     )
     self._rolling_window_process.start()
@@ -1064,13 +1273,22 @@ class GoodputMonitor:
     if not self._initialized:
       return
 
+    should_skip = (
+        skip_final_flush
+        if skip_final_flush is not None
+        else getattr(self, '_skip_final_flush', False)
+    )
+    worker_was_running = self._rolling_window_process is not None
+
     if self._rolling_window_process:
       pid = self._rolling_window_process.pid
       logger.info('Shutting down rolling window process (PID: %s)', pid)
 
+      if not should_skip:
+        self._rolling_window_final_flush_event.set()
       self._rolling_window_termination_event.set()
       self._rolling_window_process.join(
-          timeout=_PROCESS_TERMINATION_TIMEOUT_SECONDS
+          timeout=self._worker_join_timeout(should_skip)
       )
 
       if self._rolling_window_process.is_alive():
@@ -1092,17 +1310,15 @@ class GoodputMonitor:
         )
 
     self._rolling_window_process = None
-    should_skip = (
-        skip_final_flush
-        if skip_final_flush is not None
-        else getattr(self, '_skip_final_flush', False)
-    )
-    if not should_skip:
-      self._final_rolling_window_goodput_query_and_upload()
+    if not should_skip and not worker_was_running:
+      _run_with_timeout(
+          self._final_rolling_window_goodput_query_and_upload,
+          getattr(self, '_final_flush_timeout_seconds', None),
+          f'Final rolling window goodput query and upload for job: {self._worker_config["job_name"]}',
+      )
 
   def _final_rolling_window_goodput_query_and_upload(self):
     """Performs a finalrolling window goodput query and upload."""
-    time.sleep(self._worker_config['upload_interval'])
     try:
       calculator = self._goodput_calculator
       metrics_sender = self._metrics_sender

--- a/ml_goodput_measurement/src/monitoring_elastic.py
+++ b/ml_goodput_measurement/src/monitoring_elastic.py
@@ -29,6 +29,9 @@ class ElasticGoodputMonitor(monitoring.GoodputMonitor):
       step_deviation_interval_seconds: int = 10,
       gcp_options: GCPOptions = GCPOptions(),
       skip_final_flush: bool = False,
+      final_flush_timeout_seconds: (
+          float | None
+      ) = monitoring._PROCESS_TERMINATION_TIMEOUT_SECONDS,
   ):
     super().__init__(
         job_name=job_name,
@@ -43,6 +46,7 @@ class ElasticGoodputMonitor(monitoring.GoodputMonitor):
         step_deviation_interval_seconds=step_deviation_interval_seconds,
         gcp_options=gcp_options,
         skip_final_flush=skip_final_flush,
+        final_flush_timeout_seconds=final_flush_timeout_seconds,
     )
     if self._initialized:
       # Replace base calculator with elastic-aware one.

--- a/ml_goodput_measurement/tests/goodput_test.py
+++ b/ml_goodput_measurement/tests/goodput_test.py
@@ -16,6 +16,8 @@ from google3.testing.pybase import googletest
 get_timestamp_from_log_entry = goodput_utils.get_timestamp_from_log_entry
 compute_ideal_step_time = goodput_utils.compute_ideal_step_time
 BadputType = goodput_utils.BadputType
+GoodputType = goodput_utils.GoodputType
+IntervalMetricType = goodput_utils.IntervalMetricType
 
 
 # Fake job timeline information for test purposes.
@@ -1796,6 +1798,172 @@ class BadputTest(googletest.TestCase):
     )
     self.assertEqual(
         computed_badput_breakdown[BadputType.WASTED_PROGRESS_FROM_DISRUPTION], 0
+    )
+
+  def test_interval_metric_details_for_windows_matches_individual_calls_with_single_fetch(
+      self,
+  ):
+    """get_interval_metric_details_for_windows should match per-window calls to get_interval_metric_details, but using a single Cloud Logging fetch instead of one fetch per window."""
+    job_start_time = _TEST_JOB_START_TIME
+    self.goodput_recorder.record_job_start_time(job_start_time)
+
+    step_start_time = _TEST_STEP_START_TIME
+    for step in range(_TEST_TOTAL_STEPS):
+      self.goodput_recorder.record_step_start_time(step, step_start_time)
+      step_start_time += _TEST_STEP_TIME
+
+    job_end_time = step_start_time
+    self.goodput_recorder.record_job_end_time(job_end_time)
+
+    now = job_end_time
+    total_job_seconds = int((now - job_start_time).total_seconds())
+    # A small window covering only the tail of the job, and a large window
+    # that's a strict superset covering the entire job timeline.
+    small_window = max(1, total_job_seconds // 2)
+    large_window = total_job_seconds + 100
+    window_sizes = [small_window, large_window]
+
+    # Independent calculator sharing the same underlying log entries, used
+    # to compute the expected per-window baseline without disturbing the
+    # calculator under test.
+    baseline_calculator = goodput.GoodputCalculator(
+        self.job_name, self.logger_name, self.mock_cloud_logger
+    )
+    expected_results = {}
+    for window_size in window_sizes:
+      window_start = now - datetime.timedelta(seconds=window_size)
+      expected_results[window_size] = (
+          baseline_calculator.get_interval_metric_details(window_start, now)
+      )
+
+    # Count the number of Cloud Logging fetches made by the batched API.
+    original_read = self.mock_cloud_logger.read_cloud_logging_entries
+    call_count = [0]
+
+    def _counting_read(*args, **kwargs):
+      call_count[0] += 1
+      return original_read(*args, **kwargs)
+
+    self.mock_cloud_logger.read_cloud_logging_entries = _counting_read
+    try:
+      batched_results = (
+          self.goodput_calculator.get_interval_metric_details_for_windows(
+              window_sizes, now
+          )
+      )
+    finally:
+      self.mock_cloud_logger.read_cloud_logging_entries = original_read
+
+    # A single fetch (for the largest window) covers every window size.
+    self.assertEqual(call_count[0], 1)
+    self.assertEqual(set(batched_results.keys()), set(window_sizes))
+    for window_size in window_sizes:
+      self.assertEqual(
+          batched_results[window_size][
+              IntervalMetricType.INTERVAL_SIZE.value
+          ],
+          window_size,
+      )
+      self.assertAlmostEqual(
+          batched_results[window_size][
+              IntervalMetricType.INTERVAL_GOODPUT.value
+          ][GoodputType.TOTAL],
+          expected_results[window_size][
+              IntervalMetricType.INTERVAL_GOODPUT.value
+          ][GoodputType.TOTAL],
+          delta=0.01,
+      )
+      self.assertEqual(
+          batched_results[window_size][
+              IntervalMetricType.INTERVAL_BADPUT.value
+          ].keys(),
+          expected_results[window_size][
+              IntervalMetricType.INTERVAL_BADPUT.value
+          ].keys(),
+      )
+
+  def test_interval_metric_details_for_windows_empty_list(self):
+    self.assertEqual(
+        self.goodput_calculator.get_interval_metric_details_for_windows(
+            [], datetime.datetime.now(datetime.timezone.utc)
+        ),
+        {},
+    )
+
+  def test_interval_metric_details_for_windows_no_entries(self):
+    """If even the largest window has no log entries, every window size should get an empty result without raising."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    results = self.goodput_calculator.get_interval_metric_details_for_windows(
+        [60, 120], now
+    )
+    self.assertEqual(set(results.keys()), {60, 120})
+    for window_size in (60, 120):
+      self.assertEqual(
+          results[window_size],
+          {
+              IntervalMetricType.INTERVAL_GOODPUT.value: {},
+              IntervalMetricType.INTERVAL_BADPUT.value: {},
+              IntervalMetricType.INTERVAL_SIZE.value: window_size,
+          },
+      )
+
+  def test_interval_metric_details_for_windows_isolates_non_value_error_failures(
+      self,
+  ):
+    """A non-ValueError failure computing one window size must not discard results already computed for other window sizes."""
+    job_start_time = _TEST_JOB_START_TIME
+    self.goodput_recorder.record_job_start_time(job_start_time)
+
+    step_start_time = _TEST_STEP_START_TIME
+    for step in range(_TEST_TOTAL_STEPS):
+      self.goodput_recorder.record_step_start_time(step, step_start_time)
+      step_start_time += _TEST_STEP_TIME
+
+    job_end_time = step_start_time
+    self.goodput_recorder.record_job_end_time(job_end_time)
+
+    now = job_end_time
+    total_job_seconds = int((now - job_start_time).total_seconds())
+    small_window = max(1, total_job_seconds // 2)
+    large_window = total_job_seconds + 100
+    large_window_start = now - datetime.timedelta(seconds=large_window)
+
+    original_compute = (
+        self.goodput_calculator._compute_job_goodput_interval_metrics
+    )
+
+    def _flaky_compute(interval_start, interval_end):
+      if interval_start == large_window_start:
+        raise RuntimeError('boom')
+      return original_compute(interval_start, interval_end)
+
+    self.goodput_calculator._compute_job_goodput_interval_metrics = (
+        _flaky_compute
+    )
+
+    results = self.goodput_calculator.get_interval_metric_details_for_windows(
+        [small_window, large_window], now
+    )
+
+    # The failing window falls back to empty details instead of raising.
+    self.assertEqual(
+        results[large_window],
+        {
+            IntervalMetricType.INTERVAL_GOODPUT.value: {},
+            IntervalMetricType.INTERVAL_BADPUT.value: {},
+            IntervalMetricType.INTERVAL_SIZE.value: large_window,
+        },
+    )
+    # The other window's results are unaffected.
+    self.assertIn(
+        GoodputType.TOTAL,
+        results[small_window][IntervalMetricType.INTERVAL_GOODPUT.value],
+    )
+    self.assertGreater(
+        results[small_window][IntervalMetricType.INTERVAL_GOODPUT.value][
+            GoodputType.TOTAL
+        ],
+        0,
     )
 
   def _generate_step_start_times(self, number_of_steps: int, start_time):

--- a/ml_goodput_measurement/tests/monitoring_test.py
+++ b/ml_goodput_measurement/tests/monitoring_test.py
@@ -4,6 +4,8 @@ This module tests the GoodputMonitor class and its functionality, specifically
 the uploading of step deviation, goodput and badput data to Tensorboard.
 """
 
+import threading
+import time
 from unittest import mock
 
 from absl.testing import absltest
@@ -140,13 +142,19 @@ class GoodputMonitorTests(absltest.TestCase):
     mock_process_instance = mock_process.return_value
     mock_process_instance.is_alive.return_value = True
 
-    mock_goodput_event = MagicMock()
-    mock_step_deviation_event = MagicMock()
-    mock_rolling_window_event = MagicMock()
+    mock_goodput_termination_event = MagicMock()
+    mock_goodput_final_flush_event = MagicMock()
+    mock_step_deviation_termination_event = MagicMock()
+    mock_step_deviation_final_flush_event = MagicMock()
+    mock_rolling_window_termination_event = MagicMock()
+    mock_rolling_window_final_flush_event = MagicMock()
     mock_event.side_effect = [
-        mock_goodput_event,
-        mock_step_deviation_event,
-        mock_rolling_window_event,
+        mock_goodput_termination_event,
+        mock_goodput_final_flush_event,
+        mock_step_deviation_termination_event,
+        mock_step_deviation_final_flush_event,
+        mock_rolling_window_termination_event,
+        mock_rolling_window_final_flush_event,
     ]
 
     mock_summary_writer.return_value = MagicMock()
@@ -165,19 +173,26 @@ class GoodputMonitorTests(absltest.TestCase):
         target=monitoring._goodput_worker,
         args=(
             goodput_monitor._worker_config,
-            mock_goodput_event,
+            mock_goodput_termination_event,
+            mock_goodput_final_flush_event,
         ),
         daemon=True,
     )
     mock_process_instance.start.assert_called_once()
-    mock_goodput_event.clear.assert_called_once()
+    mock_goodput_termination_event.clear.assert_called_once()
+    mock_goodput_final_flush_event.clear.assert_called_once()
     goodput_monitor.stop_goodput_uploader()
-    mock_goodput_event.set.assert_called_once()
+    # The worker is asked to perform the final flush itself (using its warm
+    # cache) before exiting.
+    mock_goodput_final_flush_event.set.assert_called_once()
+    mock_goodput_termination_event.set.assert_called_once()
     mock_process_instance.join.assert_any_call(timeout=10.0)
 
     mock_process_instance.terminate.assert_called_once()
     self.assertEqual(mock_process_instance.join.call_count, 2)
-    mock_final_goodput_upload.assert_called_once()
+    # Since the worker process was running, the cold parent-side fallback
+    # query should not run.
+    mock_final_goodput_upload.assert_not_called()
     self.assertIsNone(goodput_monitor._goodput_process)
 
   @patch(
@@ -197,15 +212,7 @@ class GoodputMonitorTests(absltest.TestCase):
   ):
     mock_process_instance = mock_process.return_value
     mock_process_instance.is_alive.return_value = True
-
-    mock_goodput_event = MagicMock()
-    mock_step_deviation_event = MagicMock()
-    mock_rolling_window_event = MagicMock()
-    mock_event.side_effect = [
-        mock_goodput_event,
-        mock_step_deviation_event,
-        mock_rolling_window_event,
-    ]
+    mock_event.side_effect = lambda: MagicMock()
 
     mock_summary_writer.return_value = MagicMock()
     mock_logger_client.return_value = MagicMock()
@@ -221,6 +228,7 @@ class GoodputMonitorTests(absltest.TestCase):
 
     goodput_monitor.start_goodput_uploader()
     goodput_monitor.stop_goodput_uploader()
+    goodput_monitor._goodput_final_flush_event.set.assert_not_called()
     mock_final_goodput_upload.assert_not_called()
 
   @patch(
@@ -240,15 +248,7 @@ class GoodputMonitorTests(absltest.TestCase):
   ):
     mock_process_instance = mock_process.return_value
     mock_process_instance.is_alive.return_value = True
-
-    mock_goodput_event = MagicMock()
-    mock_step_deviation_event = MagicMock()
-    mock_rolling_window_event = MagicMock()
-    mock_event.side_effect = [
-        mock_goodput_event,
-        mock_step_deviation_event,
-        mock_rolling_window_event,
-    ]
+    mock_event.side_effect = lambda: MagicMock()
 
     mock_summary_writer.return_value = MagicMock()
     mock_logger_client.return_value = MagicMock()
@@ -264,7 +264,333 @@ class GoodputMonitorTests(absltest.TestCase):
 
     goodput_monitor.start_goodput_uploader()
     goodput_monitor.stop_goodput_uploader(skip_final_flush=True)
+    goodput_monitor._goodput_final_flush_event.set.assert_not_called()
     mock_final_goodput_upload.assert_not_called()
+
+  @patch('tensorboardX.writer.SummaryWriter')
+  @patch('google.cloud.logging.Client')
+  def test_final_flush_timeout_defaults_to_process_termination_timeout(
+      self, mock_logger_client, mock_summary_writer
+  ):
+    mock_summary_writer.return_value = MagicMock()
+    mock_logger_client.return_value = MagicMock()
+    goodput_monitor = monitoring.GoodputMonitor(
+        self.job_name,
+        self.logger_name,
+        self.tensorboard_dir,
+        upload_interval=_TEST_UPLOAD_INTERVAL,
+        monitoring_enabled=True,
+    )
+    self.assertEqual(
+        goodput_monitor._final_flush_timeout_seconds,
+        monitoring._PROCESS_TERMINATION_TIMEOUT_SECONDS,
+    )
+
+  @patch('tensorboardX.writer.SummaryWriter')
+  @patch('google.cloud.logging.Client')
+  def test_worker_join_timeout_uses_final_flush_timeout_when_flushing(
+      self, mock_logger_client, mock_summary_writer
+  ):
+    """When a final flush is requested, the join must wait long enough to cover the worker's warm flush, so it should use final_flush_timeout_seconds rather than the fixed process-termination timeout."""
+    mock_summary_writer.return_value = MagicMock()
+    mock_logger_client.return_value = MagicMock()
+    goodput_monitor = monitoring.GoodputMonitor(
+        self.job_name,
+        self.logger_name,
+        self.tensorboard_dir,
+        upload_interval=_TEST_UPLOAD_INTERVAL,
+        monitoring_enabled=True,
+        final_flush_timeout_seconds=45,
+    )
+    self.assertEqual(
+        goodput_monitor._worker_join_timeout(should_skip=False), 45
+    )
+    # With nothing to flush, there's no extra wait to budget for, so the
+    # fixed process-termination timeout applies regardless of
+    # final_flush_timeout_seconds.
+    self.assertEqual(
+        goodput_monitor._worker_join_timeout(should_skip=True),
+        monitoring._PROCESS_TERMINATION_TIMEOUT_SECONDS,
+    )
+
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring.GoodputMonitor._final_goodput_query_and_upload'
+  )
+  @patch('multiprocessing.Event')
+  @patch('multiprocessing.Process')
+  @patch('tensorboardX.writer.SummaryWriter')
+  @patch('google.cloud.logging.Client')
+  def test_stop_goodput_uploader_joins_with_custom_final_flush_timeout(
+      self,
+      mock_logger_client,
+      mock_summary_writer,
+      mock_process,
+      mock_event,
+      mock_final_goodput_upload,
+  ):
+    mock_process_instance = mock_process.return_value
+    mock_process_instance.is_alive.return_value = False
+    mock_event.side_effect = lambda: MagicMock()
+    mock_summary_writer.return_value = MagicMock()
+    mock_logger_client.return_value = MagicMock()
+
+    goodput_monitor = monitoring.GoodputMonitor(
+        self.job_name,
+        self.logger_name,
+        self.tensorboard_dir,
+        upload_interval=_TEST_UPLOAD_INTERVAL,
+        monitoring_enabled=True,
+        final_flush_timeout_seconds=45,
+    )
+
+    goodput_monitor.start_goodput_uploader()
+    goodput_monitor.stop_goodput_uploader()
+
+    mock_process_instance.join.assert_any_call(timeout=45)
+
+  def test_run_with_timeout_none_blocks_until_done(self):
+    func = MagicMock()
+    monitoring._run_with_timeout(func, None, 'test op')
+    func.assert_called_once()
+
+  def test_run_with_timeout_completes_in_time(self):
+    func = MagicMock()
+    monitoring._run_with_timeout(func, 5, 'test op')
+    func.assert_called_once()
+
+  def test_run_with_timeout_abandons_slow_func(self):
+    started = threading.Event()
+
+    def slow_func():
+      started.set()
+      time.sleep(5)
+
+    start_time = time.monotonic()
+    monitoring._run_with_timeout(slow_func, 0.1, 'slow op')
+    elapsed = time.monotonic() - start_time
+
+    self.assertTrue(started.wait(timeout=1))
+    self.assertLess(elapsed, 1)
+
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._query_and_upload_goodput_once'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_gcp_metrics_sender'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_tensorboard_writer'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_goodput_calculator'
+  )
+  def test_goodput_worker_performs_warm_final_flush_when_requested(
+      self,
+      mock_create_calculator,
+      mock_create_writer,
+      mock_create_metrics_sender,
+      mock_query_and_upload_once,
+  ):
+    mock_create_writer.return_value = MagicMock()
+    termination_event = threading.Event()
+    termination_event.set()  # Loop body never runs.
+    final_flush_event = threading.Event()
+    final_flush_event.set()
+
+    monitoring._goodput_worker(
+        {'job_name': 'test-run', 'include_badput_breakdown': False, 'upload_interval': 1},
+        termination_event,
+        final_flush_event,
+    )
+
+    mock_query_and_upload_once.assert_called_once()
+
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._query_and_upload_goodput_once'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_gcp_metrics_sender'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_tensorboard_writer'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_goodput_calculator'
+  )
+  def test_goodput_worker_skips_final_flush_when_not_requested(
+      self,
+      mock_create_calculator,
+      mock_create_writer,
+      mock_create_metrics_sender,
+      mock_query_and_upload_once,
+  ):
+    mock_create_writer.return_value = MagicMock()
+    termination_event = threading.Event()
+    termination_event.set()  # Loop body never runs.
+    final_flush_event = threading.Event()  # Not set: skip_final_flush case.
+
+    monitoring._goodput_worker(
+        {'job_name': 'test-run', 'include_badput_breakdown': False, 'upload_interval': 1},
+        termination_event,
+        final_flush_event,
+    )
+
+    mock_query_and_upload_once.assert_not_called()
+
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._query_and_upload_goodput_once'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_gcp_metrics_sender'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_tensorboard_writer'
+  )
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring._create_goodput_calculator'
+  )
+  def test_goodput_worker_notices_termination_promptly_during_long_interval(
+      self,
+      mock_create_calculator,
+      mock_create_writer,
+      mock_create_metrics_sender,
+      mock_query_and_upload_once,
+  ):
+    """A blind time.sleep(upload_interval) would make the worker miss termination_event until the interval elapses, risking forceful termination before the final flush ever runs. termination_event.wait(timeout=...) must wake up immediately instead."""
+    mock_create_writer.return_value = MagicMock()
+    termination_event = threading.Event()
+    final_flush_event = threading.Event()
+    final_flush_event.set()
+
+    worker_thread = threading.Thread(
+        target=monitoring._goodput_worker,
+        args=(
+            {
+                'job_name': 'test-run',
+                'include_badput_breakdown': False,
+                # Deliberately much longer than any reasonable termination
+                # timeout, to prove the worker doesn't just sleep through it.
+                'upload_interval': 100,
+            },
+            termination_event,
+            final_flush_event,
+        ),
+    )
+    worker_thread.start()
+    time.sleep(0.05)
+    termination_event.set()
+    worker_thread.join(timeout=1)
+
+    self.assertFalse(worker_thread.is_alive())
+    # Exactly one call: the final flush. No periodic cycle ever ran.
+    mock_query_and_upload_once.assert_called_once()
+
+  def test_query_and_upload_rolling_window_once_uses_single_batched_fetch(self):
+    """All configured window sizes should be fetched via one batched call instead of one get_interval_metric_details call per window size."""
+    calculator = MagicMock()
+    calculator.get_interval_metric_details_for_windows.return_value = {
+        3600: {
+            monitoring.IntervalMetricType.INTERVAL_GOODPUT.value: {},
+            monitoring.IntervalMetricType.INTERVAL_BADPUT.value: {},
+            monitoring.IntervalMetricType.INTERVAL_SIZE.value: 3600,
+        },
+        86400: {
+            monitoring.IntervalMetricType.INTERVAL_GOODPUT.value: {},
+            monitoring.IntervalMetricType.INTERVAL_BADPUT.value: {},
+            monitoring.IntervalMetricType.INTERVAL_SIZE.value: 86400,
+        },
+    }
+    metrics_sender = MagicMock()
+    config = {
+        'job_name': 'test-run',
+        'rolling_windows': [3600, 86400],
+        'gcp_options': GCPOptions(),
+        'include_slice_efficiency': False,
+    }
+
+    with patch(
+        'cloud_goodput.ml_goodput_measurement.src.monitoring._upload_interval_goodput_metrics_to_gcm'
+    ) as mock_upload:
+      monitoring._query_and_upload_rolling_window_once(
+          calculator, metrics_sender, config, pid=1234
+      )
+
+    calculator.get_interval_metric_details_for_windows.assert_called_once()
+    call_args = calculator.get_interval_metric_details_for_windows.call_args
+    self.assertEqual(call_args.args[0], [3600, 86400])
+    self.assertEqual(mock_upload.call_count, 2)
+
+  def test_query_and_upload_rolling_window_once_handles_fetch_error(self):
+    """A batched-fetch failure should be logged and swallowed, not raised."""
+    calculator = MagicMock()
+    calculator.get_interval_metric_details_for_windows.side_effect = Exception(
+        'boom'
+    )
+    metrics_sender = MagicMock()
+    config = {'job_name': 'test-run', 'rolling_windows': [3600, 86400]}
+
+    with patch(
+        'cloud_goodput.ml_goodput_measurement.src.monitoring._upload_interval_goodput_metrics_to_gcm'
+    ) as mock_upload:
+      monitoring._query_and_upload_rolling_window_once(
+          calculator, metrics_sender, config, pid=1234
+      )
+      mock_upload.assert_not_called()
+
+  def test_query_and_upload_rolling_window_once_isolates_per_window_upload_errors(
+      self,
+  ):
+    """An upload failure for one window size must not prevent uploading the others."""
+    calculator = MagicMock()
+    calculator.get_interval_metric_details_for_windows.return_value = {
+        3600: {monitoring.IntervalMetricType.INTERVAL_SIZE.value: 3600},
+        86400: {monitoring.IntervalMetricType.INTERVAL_SIZE.value: 86400},
+    }
+    metrics_sender = MagicMock()
+    config = {'job_name': 'test-run', 'rolling_windows': [3600, 86400]}
+
+    with patch(
+        'cloud_goodput.ml_goodput_measurement.src.monitoring._upload_interval_goodput_metrics_to_gcm'
+    ) as mock_upload:
+      mock_upload.side_effect = [Exception('boom'), None]
+      monitoring._query_and_upload_rolling_window_once(
+          calculator, metrics_sender, config, pid=1234
+      )
+      self.assertEqual(mock_upload.call_count, 2)
+
+  @patch(
+      'cloud_goodput.ml_goodput_measurement.src.monitoring.GoodputMonitor._final_goodput_query_and_upload'
+  )
+  @patch('tensorboardX.writer.SummaryWriter')
+  @patch('google.cloud.logging.Client')
+  def test_goodput_monitor_stop_without_start_uses_timeout_bounded_cold_flush(
+      self,
+      mock_logger_client,
+      mock_summary_writer,
+      mock_final_goodput_upload,
+  ):
+    """If the uploader was never started, there's no warm worker cache to use, so stop_goodput_uploader falls back to a one-off query bounded by final_flush_timeout_seconds."""
+    mock_summary_writer.return_value = MagicMock()
+    mock_logger_client.return_value = MagicMock()
+    mock_final_goodput_upload.side_effect = lambda: time.sleep(5)
+
+    goodput_monitor = monitoring.GoodputMonitor(
+        self.job_name,
+        self.logger_name,
+        self.tensorboard_dir,
+        upload_interval=_TEST_UPLOAD_INTERVAL,
+        monitoring_enabled=True,
+        final_flush_timeout_seconds=0.1,
+    )
+
+    # start_goodput_uploader() is intentionally not called: no worker process
+    # ever ran, so there is no warm cache for it to flush before exiting.
+    start_time = time.monotonic()
+    goodput_monitor.stop_goodput_uploader()
+    elapsed = time.monotonic() - start_time
+
+    mock_final_goodput_upload.assert_called_once()
+    self.assertLess(elapsed, 1)
 
   @patch(
       'cloud_goodput.ml_goodput_measurement.src.monitoring.GoodputMonitor._write_goodput_to_tensorboard'


### PR DESCRIPTION
# Description

AXLearn large-scale training job hit a fatal Python error from a multi-host barrier timeout, caused by GoodputMonitor's final metrics flush blocking too long on shutdown. 

This PR fixes the underlying cause rather than just adding a timeout:

- Cache Optimization: Move the final flush into the uploader process itself, where the cache is already warm. Each worker now performs one extra warm query+upload right before exiting.
- Timeout gate: Add final_flush_timeout_seconds (default: `_PROCESS_TERMINATION_TIMEOUT_SECONDS`) that bounds the live-worker join and the cold-fallback query, so it can be tuned to fit under a barrier deadline. `None` preserves the legacy unbounded-blocking behavior.
- Prevent Cloud Logging Quota errors: Batch rolling-window APIs to fetch once for the largest configured window and slices in-memory for smaller ones (all windows share the same end time, so the largest is a strict superset), this will cut N Cloud Logging fetches per cycle down to 1, on every periodic cycle for the life of the job, not just at shutdown.
- Fail fast: Harden per-window error handling to catch any exception, so one window's failure can't discard already-computed results for the others.

FIXES: b/529874847

# Tests

- E2E McJAX test runs: 
- Test package:https://test.pypi.org/project/ml-goodput-measurement/0.2.4/
- Elastic test runs
- CI
<img width="1833" height="766" alt="image" src="https://github.com/user-attachments/assets/ded91860-a750-4785-995b-b666999cba1b" />

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have added or updated tests for the changes I made.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to the documentation if needed.
