### PR TITLE
Release v0.2.1: replace time.sleep with Event.wait GoodputMonitor workers

### DIFF
--- a/ml_goodput_measurement/src/monitoring.py
+++ b/ml_goodput_measurement/src/monitoring.py
@@ -52,8 +52,7 @@ def _goodput_worker(config: dict, termination_event: synchronize.Event):
   summary_writer = _create_tensorboard_writer(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['upload_interval'])
+  while not termination_event.wait(timeout=config['upload_interval']):
     # Query metrics and update the cache.
     try:
       job_goodput, job_badput, last_step = calculator.get_job_goodput(
@@ -121,8 +120,7 @@ def _step_deviation_worker(config: dict, termination_event: synchronize.Event):
   summary_writer = _create_tensorboard_writer(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['step_deviation_interval_seconds'])
+  while not termination_event.wait(timeout=config['step_deviation_interval_seconds']):
     try:
       step_dev = calculator.get_step_deviation(
           config['configured_ideal_step_time']
@@ -180,8 +178,7 @@ def _rolling_window_worker(config: dict, termination_event: synchronize.Event):
   calculator = _create_goodput_calculator(config)
   metrics_sender = _create_gcp_metrics_sender(config)
 
-  while not termination_event.is_set():
-    time.sleep(config['upload_interval'])
+  while not termination_event.wait(timeout=config['upload_interval']):
     now = datetime.datetime.now(datetime.timezone.utc)
     for window_size in config['rolling_windows']:
       try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 
 [project]
 name = "ml_goodput_measurement"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Cloud TPU Team", email="cloud-tpu-eng@google.com" },
 ]


### PR DESCRIPTION
Split PR #9: apply interruptible worker sleep fix only for intermediate v0.2.1 release.

This change reverts back to d99ecb9 (v0.2.0) and manually applies the worker-sleep fix from PR #9's directly on top.

This is to help unblock immediate testing for AXLearn.

# Tests
- CI, Presubmit
- E2E MaxTest

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [ ] I have performed a self-review of my code.
- [ ] I have added or updated tests for the changes I made.
- [ ] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to the documentation if needed.
